### PR TITLE
Update all_roots_in_interval.c

### DIFF
--- a/fmpz_poly/all_roots_in_interval.c
+++ b/fmpz_poly/all_roots_in_interval.c
@@ -56,22 +56,6 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
     int sgn0_b;
 
     _fmpz_vec_set(f0, poly, n);
-    _fmpz_poly_evaluate_fmpz(val0_a, f0, n, a);
-
-    /* Remove all factors of val0_a */
-    while (fmpz_is_zero(val0_a))
-    {
-        /* {t1, 2} is available */
-        fmpz_one(t1 + 1);
-        fmpz_neg(t1 + 0, a);
-
-        _fmpz_poly_divrem(f1, f2, f0, n, t1, 2);
-        SWAP(f0, f1);
-        n--;
-
-        _fmpz_poly_evaluate_fmpz(val0_a, f0, n, a);
-    }
-
     _fmpz_poly_evaluate_fmpz(val0_b, f0, n, b);
 
     /* Remove all factors of val0_b */
@@ -86,6 +70,22 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
         n--;
 
         _fmpz_poly_evaluate_fmpz(val0_b, f0, n, b);
+    }
+
+    _fmpz_poly_evaluate_fmpz(val0_a, f0, n, a);
+
+    /* Remove all factors of val0_a */
+    while (fmpz_is_zero(val0_a))
+    {
+        /* {t1, 2} is available */
+        fmpz_one(t1 + 1);
+        fmpz_neg(t1 + 0, a);
+
+        _fmpz_poly_divrem(f1, f2, f0, n, t1, 2);
+        SWAP(f0, f1);
+        n--;
+
+        _fmpz_poly_evaluate_fmpz(val0_a, f0, n, a);
     }
 
     if (n == 1)

--- a/fmpz_poly/all_roots_in_interval.c
+++ b/fmpz_poly/all_roots_in_interval.c
@@ -56,22 +56,6 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
     int sgn0_b;
 
     _fmpz_vec_set(f0, poly, n);
-    _fmpz_poly_evaluate_fmpz(val0_b, f0, n, b);
-
-    /* Remove all factors of val0_b */
-    while (fmpz_is_zero(val0_b))
-    {
-        /* {t1, 2} is available */
-        fmpz_one(t1 + 1);
-        fmpz_neg(t1 + 0, b);
-
-        _fmpz_poly_divrem(f1, f2, f0, n, t1, 2);
-        SWAP(f0, f1);
-        n--;
-
-        _fmpz_poly_evaluate_fmpz(val0_b, f0, n, b);
-    }
-
     _fmpz_poly_evaluate_fmpz(val0_a, f0, n, a);
 
     /* Remove all factors of val0_a */
@@ -86,6 +70,24 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
         n--;
 
         _fmpz_poly_evaluate_fmpz(val0_a, f0, n, a);
+    }
+
+    _fmpz_poly_evaluate_fmpz(val0_b, f0, n, b);
+
+    /* Remove all factors of val0_b, updating val0_a */
+    fmpz_sub(c, a, b);
+    while (fmpz_is_zero(val0_b))
+    {
+        /* {t1, 2} is available */
+        fmpz_one(t1 + 1);
+        fmpz_neg(t1 + 0, b);
+
+        _fmpz_poly_divrem(f1, f2, f0, n, t1, 2);
+        SWAP(f0, f1);
+        n--;
+        fmpz_divexact(val0_a, val0_a, c);
+
+        _fmpz_poly_evaluate_fmpz(val0_b, f0, n, b);
     }
 
     if (n == 1)

--- a/fmpz_poly/all_roots_in_interval.c
+++ b/fmpz_poly/all_roots_in_interval.c
@@ -47,8 +47,8 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
     fmpz *t1     = w + 3 * n + 6;
     fmpz *t2     = w + 3 * n + 7;
 
-    fmpz *l0 = f0 + (n - 1);
-    fmpz *l1 = f1 + (n - 2);
+    fmpz *l0;
+    fmpz *l1;
 
     fmpz *t;
 
@@ -114,6 +114,9 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
             c  := - f2[n-1]
             f2 := l1 * f2 + c * f1
          */
+        l0 = f0 + n;
+        l1 = f1 + n - 1;
+
         fmpz_zero(f2 + 0);
         _fmpz_vec_scalar_mul_fmpz(f2 + 1, f1, n - 1, l0);
         _fmpz_vec_scalar_submul_fmpz(f2, f0, n, l1);
@@ -136,7 +139,7 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
 
         /* Evaluate f2 at a and b without an explicit function call */
 
-        /* val2_a = (c*val1_a + lead1*(lead0*val1_a*a - lead1*val0_a)) // d */
+        /* val2_a = (c*val1_a + l1*(l0*val1_a*a - l1*val0_a)) // d */
         fmpz_mul(t1, val1_a, a);
         fmpz_mul(t2, l0, t1);
         fmpz_submul(t2, l1, val0_a);
@@ -145,7 +148,7 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
         fmpz_swap(val0_a, val1_a);
         fmpz_divexact(val1_a, t1, d);
 
-        /* val2_b = (c*val1_b + lead1*(lead0*val1_b*b - lead1*val0_b)) // d */
+        /* val2_b = (c*val1_b + l1*(l0*val1_b*b - l1*val0_b)) // d */
         fmpz_mul(t1, val1_b, b);
         fmpz_mul(t2, l0, t1);
         fmpz_submul(t2, l1, val0_b);
@@ -154,12 +157,9 @@ int _fmpz_poly_all_roots_in_interval(fmpz *poly, slong n,
         fmpz_swap(val0_b, val1_b);
         fmpz_divexact(val1_b, t1, d);
 
-        /* Rotate the polynomials, leading coefficients, and values */
+        /* Rotate the polynomials */
         _fmpz_vec_scalar_divexact_fmpz(f0, f2, n, d);
         SWAP(f0, f1);
-
-        l0 = f0 + n;
-        l1 = f1 + n - 1;
     }
 
     return 1;


### PR DESCRIPTION
This fixes a corner-case bug in the early-abort Sturm sequence code. In cases where one of the endpoints is a root of the polynomial, the SWAP{f0, f1} command left the leading coefficient pointers l0, l1 dangling. To fix this, we leave these unassigned at first and only assign them in the loop just before computing the pseudoremainder.
